### PR TITLE
allow null city

### DIFF
--- a/exercises/movr/users/data/users_database.sql
+++ b/exercises/movr/users/data/users_database.sql
@@ -2,7 +2,7 @@ CREATE DATABASE movr_users;
 
 CREATE TABLE movr_users.users (
 	email STRING PRIMARY KEY,
-	city STRING NOT NULL,
+	city STRING NULL,
 	last_name STRING NOT NULL,
 	first_name STRING NOT NULL,
 	phone_numbers STRING[] NOT NULL

--- a/solutions/00-initial-state/movr/users/data/users_database.sql
+++ b/solutions/00-initial-state/movr/users/data/users_database.sql
@@ -2,7 +2,7 @@ CREATE DATABASE movr_users;
 
 CREATE TABLE movr_users.users (
 	email STRING PRIMARY KEY,
-	city STRING NOT NULL,
+	city STRING NULL,
 	last_name STRING NOT NULL,
 	first_name STRING NOT NULL,
 	phone_numbers STRING[] NOT NULL

--- a/solutions/01-identifying-necessary-regions/movr/users/data/users_database.sql
+++ b/solutions/01-identifying-necessary-regions/movr/users/data/users_database.sql
@@ -2,7 +2,7 @@ CREATE DATABASE movr_users;
 
 CREATE TABLE movr_users.users (
 	email STRING PRIMARY KEY,
-	city STRING NOT NULL,
+	city STRING NULL,
 	last_name STRING NOT NULL,
 	first_name STRING NOT NULL,
 	phone_numbers STRING[] NOT NULL

--- a/solutions/02-poor-resilience/movr/users/data/users_database.sql
+++ b/solutions/02-poor-resilience/movr/users/data/users_database.sql
@@ -2,7 +2,7 @@ CREATE DATABASE movr_users;
 
 CREATE TABLE movr_users.users (
 	email STRING PRIMARY KEY,
-	city STRING NOT NULL,
+	city STRING NULL,
 	last_name STRING NOT NULL,
 	first_name STRING NOT NULL,
 	phone_numbers STRING[] NOT NULL

--- a/solutions/03-implement-multi-region-db/movr/users/data/users_database.sql
+++ b/solutions/03-implement-multi-region-db/movr/users/data/users_database.sql
@@ -2,7 +2,7 @@ CREATE DATABASE movr_users;
 
 CREATE TABLE movr_users.users (
 	email STRING PRIMARY KEY,
-	city STRING NOT NULL,
+	city STRING NULL,
 	last_name STRING NOT NULL,
 	first_name STRING NOT NULL,
 	phone_numbers STRING[] NOT NULL

--- a/solutions/04-survival-goals/movr/users/data/users_database.sql
+++ b/solutions/04-survival-goals/movr/users/data/users_database.sql
@@ -2,7 +2,7 @@ CREATE DATABASE movr_users;
 
 CREATE TABLE movr_users.users (
 	email STRING PRIMARY KEY,
-	city STRING NOT NULL,
+	city STRING NULL,
 	last_name STRING NOT NULL,
 	first_name STRING NOT NULL,
 	phone_numbers STRING[] NOT NULL

--- a/solutions/05-global-tables/movr/users/data/users_database.sql
+++ b/solutions/05-global-tables/movr/users/data/users_database.sql
@@ -2,7 +2,7 @@ CREATE DATABASE movr_users;
 
 CREATE TABLE movr_users.users (
 	email STRING PRIMARY KEY,
-	city STRING NOT NULL,
+	city STRING NULL,
 	last_name STRING NOT NULL,
 	first_name STRING NOT NULL,
 	phone_numbers STRING[] NOT NULL

--- a/solutions/06-regional-by-row/movr/users/data/users_database.sql
+++ b/solutions/06-regional-by-row/movr/users/data/users_database.sql
@@ -2,7 +2,7 @@ CREATE DATABASE movr_users;
 
 CREATE TABLE movr_users.users (
 	email STRING PRIMARY KEY,
-	city STRING NOT NULL,
+	city STRING NULL,
 	last_name STRING NOT NULL,
 	first_name STRING NOT NULL,
 	phone_numbers STRING[] NOT NULL

--- a/solutions/07-regional-tables/movr/users/data/users_database.sql
+++ b/solutions/07-regional-tables/movr/users/data/users_database.sql
@@ -2,7 +2,7 @@ CREATE DATABASE movr_users;
 
 CREATE TABLE movr_users.users (
 	email STRING PRIMARY KEY,
-	city STRING NOT NULL,
+	city STRING NULL,
 	last_name STRING NOT NULL,
 	first_name STRING NOT NULL,
 	phone_numbers STRING[] NOT NULL

--- a/solutions/08-placement-restricted/users/data/users_database.sql
+++ b/solutions/08-placement-restricted/users/data/users_database.sql
@@ -2,7 +2,7 @@ CREATE DATABASE movr_users;
 
 CREATE TABLE movr_users.users (
 	email STRING PRIMARY KEY,
-	city STRING NOT NULL,
+	city STRING NULL,
 	last_name STRING NOT NULL,
 	first_name STRING NOT NULL,
 	phone_numbers STRING[] NOT NULL

--- a/solutions/09-tradeoffs/movr/users/data/users_database.sql
+++ b/solutions/09-tradeoffs/movr/users/data/users_database.sql
@@ -2,7 +2,7 @@ CREATE DATABASE movr_users;
 
 CREATE TABLE movr_users.users (
 	email STRING PRIMARY KEY,
-	city STRING NOT NULL,
+	city STRING NULL,
 	last_name STRING NOT NULL,
 	first_name STRING NOT NULL,
 	phone_numbers STRING[] NOT NULL


### PR DESCRIPTION
Updating exercise databases to allow null city. This field is used in the regional by row exercise. 

Although not being used in the exercise, the training movr application would need to be updated to accept include a city if we want to use it for future exercise demonstrations. 

Not updating the application during M1 as we're likely to need a larger discussion around preventing movr app customizations for single courses.